### PR TITLE
Bump go to remediate cves

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module package-manager
 
-go 1.22.7
+go 1.22.11
 
 require (
 	github.com/google/go-github/v39 v39.2.0


### PR DESCRIPTION
go lang remediated a few cve's since .7 - "security fixes to the crypto/x509 and net/http packages"